### PR TITLE
Add enemy AI, longer dash and sword slash visuals

### DIFF
--- a/effects.py
+++ b/effects.py
@@ -1,0 +1,44 @@
+import math
+import pygame
+
+
+class SlashEffect:
+    def __init__(self, pos, direction, arc, radius, duration=0.3, charge_factor=0.0):
+        self.pos = pygame.Vector2(pos)
+        self.dir = pygame.Vector2(direction)
+        if self.dir.length_squared() == 0:
+            self.dir = pygame.Vector2(1, 0)
+        else:
+            self.dir = self.dir.normalize()
+        self.arc = arc
+        self.radius = radius
+        self.time_left = duration
+        self.duration = duration
+        self.charge = charge_factor
+
+    def update(self, dt):
+        self.time_left -= dt
+
+    def is_done(self):
+        return self.time_left <= 0
+
+    def draw(self, surface, camera):
+        if self.time_left <= 0:
+            return
+        screen_pos = camera.world_to_screen(self.pos, surface.get_size())
+        size = int(self.radius * 2)
+        arc_surface = pygame.Surface((size, size), pygame.SRCALPHA)
+        center = pygame.Vector2(self.radius, self.radius)
+        start_angle = math.atan2(self.dir.y, self.dir.x) - self.arc / 2
+        steps = 20
+        points = [center]
+        for i in range(steps + 1):
+            ang = start_angle + self.arc * i / steps
+            p = center + pygame.Vector2(math.cos(ang), math.sin(ang)) * self.radius
+            points.append(p)
+        alpha = max(0, int(180 * (1 + self.charge) * (self.time_left / self.duration)))
+        if alpha > 255:
+            alpha = 255
+        color = (255, 255, 255, alpha)
+        pygame.draw.polygon(arc_surface, color, points)
+        surface.blit(arc_surface, (screen_pos.x - self.radius, screen_pos.y - self.radius))

--- a/enemies.py
+++ b/enemies.py
@@ -1,18 +1,49 @@
 import pygame
 
+ENEMY_HP = 40
+ENEMY_SPEED = 200
+ENEMY_DAMAGE = 10
+ENEMY_ATTACK_RANGE = 40
+ENEMY_WINDUP = 0.3
+ENEMY_COOLDOWN = 1.0
+
 
 class Enemy:
     def __init__(self, pos, radius=20, color=(200, 50, 50)):
         self.pos = pygame.Vector2(pos)
         self.radius = radius
         self.color = color
-        self.hp = 100
+        self.hp = ENEMY_HP
+        self.speed = ENEMY_SPEED
+        self.damage = ENEMY_DAMAGE
+        self.attack_range = ENEMY_ATTACK_RANGE
+        self.windup = ENEMY_WINDUP
+        self.cooldown = ENEMY_COOLDOWN
+        self.attack_timer = 0
+        self.windup_timer = 0
 
     def take_damage(self, damage):
         self.hp -= damage
 
     def is_dead(self):
         return self.hp <= 0
+
+    def update(self, dt, player):
+        if self.hp <= 0:
+            return
+        to_player = player.pos - self.pos
+        dist = to_player.length()
+        direction = to_player.normalize() if dist > 0 else pygame.Vector2()
+        self.attack_timer = max(0, self.attack_timer - dt)
+        if self.windup_timer > 0:
+            self.windup_timer -= dt
+            if self.windup_timer <= 0 and dist <= self.attack_range:
+                player.take_damage(self.damage)
+                self.attack_timer = self.cooldown
+        elif dist <= self.attack_range and self.attack_timer <= 0:
+            self.windup_timer = self.windup
+        else:
+            self.pos += direction * self.speed * dt
 
     def draw(self, surface, camera):
         screen_pos = camera.world_to_screen(self.pos, surface.get_size())

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 import math
+import random
 import pygame
 
 from input_handler import InputHandler
 from weapons import ChargeAttack, MeleeWeapon, RangedWeapon
 from enemies import Enemy
+from effects import SlashEffect
 
 # Constants
 WINDOW_WIDTH = 1280
@@ -19,10 +21,13 @@ MAX_ZOOM = 4.0
 ZOOM_STEP = 1.1
 
 PLAYER_SPEED = 500
-DASH_SPEED = 1400
-DASH_TIME = 0.14
-DASH_COOLDOWN = 0.90
-DASH_IFRAMES = 0.16
+PLAYER_MAX_HP = 100
+DASH_SPEED = 1600
+DASH_TIME = 0.25
+DASH_COOLDOWN = 1.0
+DASH_IFRAMES = 0.18
+
+ENEMY_SPAWN_INTERVAL = 2.5
 
 
 class Camera:
@@ -48,6 +53,7 @@ class Player:
         self.radius = radius
         self.color = color
         self.speed = PLAYER_SPEED
+        self.hp = PLAYER_MAX_HP
         self.dash_time_left = 0
         self.dash_cooldown_left = 0
         self.iframes_left = 0
@@ -83,6 +89,11 @@ class Player:
         screen_pos = camera.world_to_screen(self.pos, surface.get_size())
         color = self.color if self.iframes_left <= 0 else (100, 100, 255)
         pygame.draw.circle(surface, color, (int(screen_pos.x), int(screen_pos.y)), self.radius)
+
+    def take_damage(self, dmg):
+        if self.iframes_left > 0 or self.dash_time_left > 0:
+            return
+        self.hp = max(0, self.hp - dmg)
 
     def try_dash(self):
         if self.dash_cooldown_left > 0 or self.dash_time_left > 0:
@@ -128,7 +139,11 @@ class Game:
 
         self.input = InputHandler()
         self.projectiles = []
-        self.enemies = [Enemy((300, 0)), Enemy((400, 200))]
+        self.enemies = []
+        self.slashes = []
+        self.spawn_timer = ENEMY_SPAWN_INTERVAL
+        self.total_spawned = 0
+        self.elapsed_time = 0
         self.melee = MeleeWeapon(self.player, ChargeAttack(0.7))
         self.ranged = RangedWeapon(self.player, ChargeAttack(1.0))
 
@@ -170,10 +185,23 @@ class Game:
                 if not self.player.is_dashing():
                     self.input.handle_event(event)
 
+    def spawn_enemy(self):
+        angle = random.uniform(0, 2 * math.pi)
+        distance = 600
+        pos = self.player.pos + pygame.Vector2(math.cos(angle), math.sin(angle)) * distance
+        self.enemies.append(Enemy(pos))
+
     def update(self, dt):
         keys = pygame.key.get_pressed()
         self.player.update(dt, keys)
         self.input.update(dt)
+
+        self.elapsed_time += dt
+        self.spawn_timer -= dt
+        if self.spawn_timer <= 0:
+            self.spawn_enemy()
+            self.spawn_timer = ENEMY_SPAWN_INTERVAL
+            self.total_spawned += 1
 
         mouse_world = self.camera.screen_to_world(
             pygame.mouse.get_pos(), self.screen.get_size()
@@ -185,7 +213,19 @@ class Game:
             aim_dir = aim_dir.normalize()
 
         if self.input.left.just_released and not self.player.is_dashing():
-            self.melee.attack(self.enemies, self.input.left.time, aim_dir)
+            hits, attack_range, arc, cf = self.melee.attack(
+                self.enemies, self.input.left.time, aim_dir
+            )
+            self.slashes.append(
+                SlashEffect(
+                    self.player.pos,
+                    aim_dir,
+                    arc,
+                    attack_range,
+                    0.2 + 0.2 * cf,
+                    cf,
+                )
+            )
         if self.input.right.just_released and not self.player.is_dashing():
             self.ranged.attack(self.projectiles, self.input.right.time, aim_dir)
 
@@ -196,7 +236,18 @@ class Game:
             if not projectile.alive:
                 self.projectiles.remove(projectile)
 
-        self.enemies = [e for e in self.enemies if not e.is_dead()]
+        for enemy in list(self.enemies):
+            enemy.update(dt, self.player)
+            if enemy.is_dead():
+                self.enemies.remove(enemy)
+
+        for slash in list(self.slashes):
+            slash.update(dt)
+            if slash.is_done():
+                self.slashes.remove(slash)
+
+        if self.player.hp <= 0:
+            self.running = False
 
         self.camera.center_on(self.player.pos)
 
@@ -226,10 +277,14 @@ class Game:
         pygame.draw.line(self.screen, ORIGIN_COLOR, (ox, oy - 5), (ox, oy + 5), 1)
 
     def draw_overlay(self):
+        spawn_rate = (
+            self.total_spawned / self.elapsed_time if self.elapsed_time > 0 else 0
+        )
+        enemy_hp = self.enemies[0].hp if self.enemies else 0
         text = (
-            f"Player: ({self.player.pos.x:.1f}, {self.player.pos.y:.1f})  "
-            f"Zoom: {self.camera.zoom:.2f}  FPS: {self.clock.get_fps():.1f}  "
-            f"Dash CD: {self.player.dash_cooldown_left:.1f}  I-Frames: {self.player.iframes_left:.2f}  "
+            f"Player HP: {self.player.hp:.0f}  Enemies: {len(self.enemies)}  "
+            f"Spawn: {spawn_rate:.2f}/s  Enemy HP: {enemy_hp:.0f}  "
+            f"Dash: {self.player.dash_time_left:.2f}/{self.player.dash_cooldown_left:.2f}  "
             f"MCharge: {self.melee.charge.factor(self.input.left.time):.2f}  "
             f"RCharge: {self.ranged.charge.factor(self.input.right.time):.2f}"
         )
@@ -244,6 +299,8 @@ class Game:
         for projectile in self.projectiles:
             projectile.draw(self.screen, self.camera)
         self.player.draw(self.screen, self.camera)
+        for slash in self.slashes:
+            slash.draw(self.screen, self.camera)
         self.draw_overlay()
         pygame.display.flip()
 

--- a/weapons.py
+++ b/weapons.py
@@ -33,11 +33,13 @@ class MeleeWeapon:
             to_enemy = enemy.pos - self.owner.pos
             dist = to_enemy.length()
             if dist <= attack_range and dist > 0:
-                angle = math.acos(max(-1.0, min(direction.dot(to_enemy.normalize()), 1.0)))
+                angle = math.acos(
+                    max(-1.0, min(direction.dot(to_enemy.normalize()), 1.0))
+                )
                 if angle <= arc / 2:
                     enemy.take_damage(damage)
                     hits.append(enemy)
-        return hits
+        return hits, attack_range, arc, charge_factor
 
 
 class RangedWeapon:


### PR DESCRIPTION
## Summary
- lengthen dash and add player HP handling
- spawn and update simple chasing enemies with melee attacks
- render fading sword slash sector

## Testing
- `python -m py_compile main.py input_handler.py weapons.py projectiles.py enemies.py effects.py`


------
https://chatgpt.com/codex/tasks/task_e_68a975d94180832e920fd5cf1b07d30a